### PR TITLE
Add repetition-based stopping option

### DIFF
--- a/tests/test_repetition.py
+++ b/tests/test_repetition.py
@@ -1,0 +1,23 @@
+import pytest
+
+from faster_whisper.transcribe import _truncate_repetition
+
+
+def test_truncate_single_token():
+    tokens = [1, 1, 1, 1, 1]
+    assert _truncate_repetition(tokens, 5) == []
+
+
+def test_truncate_pattern():
+    tokens = [1, 2] * 5
+    assert _truncate_repetition(tokens, 5) == []
+
+
+def test_no_truncate_when_below_threshold():
+    tokens = [3, 3, 3, 3]
+    assert _truncate_repetition(tokens, 5) == tokens
+
+
+def test_truncate_with_prefix():
+    tokens = [7, 8, 9, 9, 9, 9, 9]
+    assert _truncate_repetition(tokens, 5) == [7, 8]


### PR DESCRIPTION
## Summary
- allow transcribe methods to stop when a token sequence repeats via new `max_repetition` option
- trim repeated tails in generation and batched generation
- add unit tests for repetition truncation

## Testing
- `python -m pytest tests/test_repetition.py -q`
- `python -m pytest -q` *(fails: LocalEntryNotFoundError: Cannot find an appropriate cached snapshot folder)*

------
https://chatgpt.com/codex/tasks/task_e_68936e4569788326b629614004328096