### PR TITLE
Add token streaming API and FastAPI example

### DIFF
--- a/fastapi_streaming.py
+++ b/fastapi_streaming.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI, UploadFile
+from fastapi.responses import StreamingResponse
+
+from faster_whisper import WhisperModel
+
+model = WhisperModel("base")
+app = FastAPI()
+
+
+@app.post("/transcribe")
+async def transcribe(file: UploadFile):
+    def token_generator():
+        for token in model.transcribe_stream(file.file):
+            yield f"data: {token['text']}\n\n"
+
+    return StreamingResponse(token_generator(), media_type="text/event-stream")
+


### PR DESCRIPTION
## Summary
- expose `transcribe_stream` to yield tokens while decoding
- provide a minimal FastAPI server demonstrating token streaming

## Testing
- `PYTHONPATH=. pytest` *(fails: LocalEntryNotFoundError: Cannot find an appropriate cached file)*

------
https://chatgpt.com/codex/tasks/task_e_689404fc25b083268aeb16f5a252aad0