### PR TITLE
Handle repetition termination in streaming

### DIFF
--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -1045,6 +1045,8 @@ class WhisperModel:
             ``text`` representation.
         """
 
+        max_repetition = kwargs.get("max_repetition")
+
         segments, info = self.transcribe(
             audio, language=language, task=task, **kwargs
         )
@@ -1056,8 +1058,19 @@ class WhisperModel:
         )
 
         for segment in segments:
-            for token in segment.tokens:
+            tokens = segment.tokens
+            truncated = False
+
+            if max_repetition is not None:
+                new_tokens = _truncate_repetition(tokens, max_repetition)
+                truncated = len(new_tokens) < len(tokens)
+                tokens = new_tokens
+
+            for token in tokens:
                 yield {"token": int(token), "text": tokenizer.decode([token])}
+
+            if truncated:
+                break
 
     def _split_segments_by_timestamps(
         self,


### PR DESCRIPTION
## Summary
- terminate `transcribe_stream` when repeated token patterns appear

## Testing
- `PYTHONPATH=. pytest -q` *(fails: huggingface_hub.errors.LocalEntryNotFoundError: Cannot find an appropriate cached snapshot folder for the specified revision on the local disk and outgoing traffic has been disabled)*

------
https://chatgpt.com/codex/tasks/task_e_689cace9e0ec8326b4c112b408a9f01e